### PR TITLE
Update CLI options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 tmp/
 *.stack-work/
+*.org

--- a/blueprint-cli/app/Main.hs
+++ b/blueprint-cli/app/Main.hs
@@ -42,7 +42,18 @@ import           GHC.Utils.Outputable            ( ppr, showPprUnsafe )
 
 
 main :: IO ()
-main = undefined -- runner4
+main = undefined >> exactprint >>= putStrLn
+
+runner :: IO ()
+runner = runGhcT (Just libdir) $ do
+  sEnv <- liftIO getSearchEnv
+  let ent = entity sEnv
+  let filePath = modPath sEnv
+  modSum <- runExcept $ initializeGhc filePath
+  case modsum of
+    Right x -> undefined
+    Left _ -> putStrLn "exited"
+  return ()
 
 
 -- runner1 :: IO ()

--- a/blueprint-cli/app/Main.hs
+++ b/blueprint-cli/app/Main.hs
@@ -17,12 +17,13 @@ import           Data.Tree                       ( drawTree )
 
 import           Development.Blueprint           ( initializeGhc, seeDefUses,
                                                    seeFromTcGblEnv )
-import           Development.Blueprint.App       ( runBluePrint )
+import           Development.Blueprint.Monad  ( runBluePrint )
 import           Development.Blueprint.Compute   ( entityToGlbRdrElt,
                                                    entityToName,
                                                    searchInDefUses, valBindsToHsBinds )
 import           Development.Blueprint.Types     ( Entity (..), SearchEnv (..) )
 import           Development.Blueprint.Types.AST ( BluePrintAST (..) )
+import           CLI
 
 import           GHC
 import           GHC.Data.OrdList                ( fromOL )
@@ -41,20 +42,22 @@ import           GHC.Types.Name.Set
 import           GHC.Utils.Outputable            ( ppr, showPprUnsafe )
 
 
-main :: IO ()
-main = undefined >> exactprint >>= putStrLn
+-- main :: IO ()
+-- main = undefined >> exactprint >>= putStrLn
 
 runner :: IO ()
 runner = runGhcT (Just libdir) $ do
   sEnv <- liftIO getSearchEnv
   let ent = entity sEnv
   let filePath = modPath sEnv
-  modSum <- runExcept $ initializeGhc filePath
-  case modsum of
-    Right x -> undefined
-    Left _ -> putStrLn "exited"
+  -- modSum <- runExcept $ initializeGhc filePath
+  -- case modSum of
+  --   Right x -> undefined
+  --   Left _ -> undefined
   return ()
 
+
+main = runner
 
 -- runner1 :: IO ()
 -- runner1 = runGhcT (Just libdir) $ do
@@ -157,14 +160,8 @@ runner = runGhcT (Just libdir) $ do
 -- printGatheredSEnv = commandLineInterface >>= print
 
 
--- commandLineInterface :: IO SearchEnv
--- commandLineInterface = do
---   execParser (info (parseSearchEnv <**> helper)
---                           (fullDesc <> progDesc "Print recursive declerations of an entity"
---                            <> header "A different approach to showing outgoing call hierarchy for Haskell source code."))
-
--- getSearchEnv :: IO SearchEnv
--- getSearchEnv = commandLineInterface
+getSearchEnv :: IO SearchEnv
+getSearchEnv = commandLineInterface
 
 
 parseSourceFile' :: GhcMonad m => LoadHowMuch -> FilePath -> m ParsedModule
@@ -174,8 +171,61 @@ parseSourceFile' loadHowMuch filePath = do
     setSessionDynFlags $ dflags { backend = NoBackend }
     target <- guessTarget filePath Nothing
     setTargets [target]
-    load loadHowMuch -- TODO construct a Unit in order to feed your path to your module
+    load loadHowMuch
     modSum <- getModSummary $ mkModuleName fileModuleName
     parseModule modSum
   where
     mkFileModName = reverse . takeWhile (/= '/') . reverse . (\fp -> take (length fp - 3) fp)
+
+
+
+-- | Given a function name and its right-hand side, substitute every call to that function with its RHS in the given Haskell module.
+-- substituteFunction :: forall a. (GhcMonad m) => String -> String -> ModuleName -> m (Either String a)
+-- substituteFunction functionName rhs moduleName = do
+--   -- Initialize GHC session with default settings
+--   dflags <- getSessionDynFlags
+--   defaultCleanupHandler dflags $ do
+--     -- Parse the module and get its AST
+--     target <- guessTarget (moduleNameToStr moduleName) Nothing
+--     setTargets [target]
+--     load LoadAllTargets
+--     modSum <- getModSummary $ mkModuleName $ moduleNameToStr moduleName
+--     p <- parseModule modSum
+--     t <- typecheckModule p
+
+--     -- Traverse the AST and substitute every call to the given function with its RHS
+--     let ast = tm_parsed_module $ snd t
+--         ast' = everywhere (mkT substitute) ast
+--         substitute :: LHsExpr GhcPs -> LHsExpr GhcPs
+--         substitute (L loc (HsVar _ (L _ name))) | nameToStr name == functionName =
+--           case parseExpr rhs of
+--             Left err -> error $ "Failed to parse RHS: " ++ err
+--             Right rhsAst -> L loc rhsAst
+--         substitute expr = expr
+
+--     -- Output the modified AST if desired
+--     -- liftIO $ putStrLn $ showSDoc dflags $ ppr ast'
+
+--     -- Typecheck the modified AST and return the result
+--     t' <- typecheckModule $ t { tm_parsed_module = ast' }
+--     let errs = bagToList $ snd $ getMessages $ hsc_dflags $ snd t'
+--     case errs of
+--       [] -> return $ Right undefined -- Return a dummy value to satisfy the type signature
+--       _ -> return $ Left $ "Type errors occurred: " ++ intercalate "\n" (map show errs)
+
+-- -- | Convert a module name to a string
+-- moduleNameToStr :: ModuleName -> String
+-- moduleNameToStr = undefined
+-- -- moduleNameToStr (ModuleName str) = str
+
+-- -- | Convert a name to a string
+-- nameToStr :: Name -> String
+-- nameToStr = occNameString . rdrNameOcc . nameRdrName
+
+-- -- | Example usage
+-- main :: IO ()
+-- main = runGhc (Just libdir) $ do
+--   res <- substituteFunction "foo" "42" (ModuleName "Main")
+--   case res of
+--     Left err -> liftIO $ putStrLn err
+--     Right _ -> liftIO $ putStrLn "Substitution successful"

--- a/blueprint-cli/src/CLI.hs
+++ b/blueprint-cli/src/CLI.hs
@@ -1,4 +1,13 @@
 -- module CLI (parseSearchEnv) where
-module CLI ( module CLI.Parser ) where
+module CLI ( commandLineInterface ) where
 
 import           CLI.Parser
+import Development.Blueprint.Types
+import Options.Applicative
+
+
+commandLineInterface :: IO SearchEnv
+commandLineInterface = do
+  execParser (info (parseSearchEnv <**> helper)
+                          (fullDesc <> progDesc "Print recursive declerations of an entity"
+                           <> header "A different approach to showing outgoing call hierarchy for Haskell source code."))

--- a/blueprint-cli/src/CLI/Parser.hs
+++ b/blueprint-cli/src/CLI/Parser.hs
@@ -63,7 +63,7 @@ parseLineNumber = switch (long "line-number" <> short 'n'
 parseOutputType :: Parser OutputType
 parseOutputType = parseAscii <|> parseImage <|> parseSource
   where parseImage = Image <$> option parseV (long "image" <> short 'i' <> metavar "FILE" <> value Browser <> help "Write the result to an image")
-        parseAscii = Ascii <$> option parseF (long "minamal" <> short 'm' <> value STDIO <> help "Prints a minimal result to Stdio or a filepath")
+        parseAscii = Ascii <$> option parseF (long "ascii" <> short 'a' <> value STDIO <> help "Prints a minimal result to Stdio or a filepath")
         parseSource = SourceCode <$> option parseF (long "source-code" <> short 's' <> value STDIO <> help "Write the result as a Haskell source to a filePath")
         parseF = maybeReader $ \x -> Just (File x)
         parseV = maybeReader $ \x -> Just (DumpFile x)

--- a/blueprint-cli/src/CLI/Parser.hs
+++ b/blueprint-cli/src/CLI/Parser.hs
@@ -7,15 +7,18 @@ import           Control.Applicative         ( (<|>) )
 import           Data.Text                   ( pack )
 
 import           Development.Blueprint.Types ( DepthLevel (..), Entity (..),
+                                               EntityName, Func(..),
                                                LocalFunc, OutputType (..),
+                                               OutputFormat(..),
                                                Print (..), Scope (..),
                                                SearchEnv (..), TypeC (..),
                                                VisualView (..) )
 
-import           Options.Applicative         ( Parser, argument, flag, help,
-                                               long, metavar, short, str,
+import           Options.Applicative         ( Parser, ReadM, argument, flag,
+                                               help, long, metavar, optional,
+                                               readerError, short, str,
                                                strOption, switch )
-import           Options.Applicative.Builder ( command, info, maybeReader,
+import           Options.Applicative.Builder ( auto, command, info, maybeReader,
                                                option, progDesc, subparser,
                                                value )
 
@@ -27,19 +30,20 @@ parseFilePath = argument str (metavar "FILENAME")
 
 -- subparser for the blueprint command: function and type
 parseCommand :: Parser Entity
-parseCommand = subparser $ funcCommand <> typeCommand
+parseCommand = subparser $ funcCommand <> typeCommand <> subCommand <> showCommand
   where funcCommand = command "function" (info parseFuncCommand (progDesc "Get the blueprint of a function."))
         typeCommand = command "type" (info parseTypeCommand (progDesc "Get the blueprint of a data type."))
-
+        subCommand = command "substitude" (info parseSubCommand (progDesc "Get the blueprint of a function or type with term substitution."))
+        showCommand = command "show" (info parseShowCommand (progDesc "Show the blueprint of a function or type ingiven format: 'ascii', 'img'"))
 
 parseFuncCommand :: Parser Entity
 parseFuncCommand = FunctionE <$> (toScope <$> parseFunc <*> parseScope ) <*> parseSignature -- FunctionE <$> parseFunc <*> parseScope <*> parseSignature
   where parseSignature = switch (long "type-signatures" <> short 'T' <> help "Get the blueprint of a function and show its type-signature")
+        parseFunc :: Parser Func
         parseFunc = argument str (metavar "FUNCTION NAME")
         parseScope :: Parser (Maybe LocalFunc)
         parseScope = option (maybeReader $ \x -> Just (Just (pack x))) (short 'l' <> long "local-func" <> value Nothing <> help "Get the blueprint of a local function")
-        toScope func Nothing          = TopLevel func
-        toScope func (Just localFunc) = ParentS func localFunc
+        toScope func = maybe (TopLevel func) (ParentS func)
 
 -- parses the function command, its options and flags
 parseTypeCommand :: Parser Entity
@@ -47,6 +51,24 @@ parseTypeCommand =  DataTypeE <$> parseTyConf
   where parseTySynOption = switch (long "type-synonyms" <> short 't' <> help "Show the real types of type synonyms")
         parseTyConf = TypeC <$> argument str (metavar "TYPE NAME")
                                 <*> parseTySynOption
+
+parseSubCommand :: Parser Entity
+parseSubCommand = SubstituteE <$> parseEntityName <*> parseSubLevel
+  where parseSubLevel = optional $ option auto (long "max-level" <> short 'L' <> help "Maximum level of substitution")
+
+parseEntityName :: Parser EntityName
+parseEntityName = argument str (metavar "NAME")
+
+parseShowCommand :: Parser Entity
+parseShowCommand = ShowE <$> parseEntityName <*> parseFormat
+  where
+    parseFormat = option parseOutputFmt (long "output-format" <> short 'o' <>
+      help "Output format. Can be 'ascii', 'img'")
+    parseOutputFmt :: ReadM OutputFormat
+    parseOutputFmt = str @String >>= \case
+      "ascii" -> pure FmtAscii
+      "img" -> pure FmtImg
+      _ -> readerError "Unsupported output format. Use 'ascii' or 'img'"
 
 -- parses the Level option (number of the levels to go through AST)
 parseLevelOption :: Parser DepthLevel

--- a/blueprint-cli/src/CLI/Parser.hs
+++ b/blueprint-cli/src/CLI/Parser.hs
@@ -2,14 +2,13 @@
 
 module CLI.Parser where
 
-import           Control.Applicative         ( (<|>) )
+import           Control.Applicative         ( (<|>), many )
 
 import           Data.Text                   ( pack )
 
 import           Development.Blueprint.Types ( DepthLevel (..), Entity (..),
                                                EntityName, Func(..),
                                                LocalFunc, OutputType (..),
-                                               OutputFormat(..),
                                                Print (..), Scope (..),
                                                SearchEnv (..), TypeC (..),
                                                VisualView (..) )
@@ -30,45 +29,18 @@ parseFilePath = argument str (metavar "FILENAME")
 
 -- subparser for the blueprint command: function and type
 parseCommand :: Parser Entity
-parseCommand = subparser $ funcCommand <> typeCommand <> subCommand <> showCommand
-  where funcCommand = command "function" (info parseFuncCommand (progDesc "Get the blueprint of a function."))
-        typeCommand = command "type" (info parseTypeCommand (progDesc "Get the blueprint of a data type."))
-        subCommand = command "substitude" (info parseSubCommand (progDesc "Get the blueprint of a function or type with term substitution."))
-        showCommand = command "show" (info parseShowCommand (progDesc "Show the blueprint of a function or type ingiven format: 'ascii', 'img'"))
-
-parseFuncCommand :: Parser Entity
-parseFuncCommand = FunctionE <$> (toScope <$> parseFunc <*> parseScope ) <*> parseSignature -- FunctionE <$> parseFunc <*> parseScope <*> parseSignature
-  where parseSignature = switch (long "type-signatures" <> short 'T' <> help "Get the blueprint of a function and show its type-signature")
-        parseFunc :: Parser Func
-        parseFunc = argument str (metavar "FUNCTION NAME")
-        parseScope :: Parser (Maybe LocalFunc)
-        parseScope = option (maybeReader $ \x -> Just (Just (pack x))) (short 'l' <> long "local-func" <> value Nothing <> help "Get the blueprint of a local function")
-        toScope func = maybe (TopLevel func) (ParentS func)
-
--- parses the function command, its options and flags
-parseTypeCommand :: Parser Entity
-parseTypeCommand =  DataTypeE <$> parseTyConf
-  where parseTySynOption = switch (long "type-synonyms" <> short 't' <> help "Show the real types of type synonyms")
-        parseTyConf = TypeC <$> argument str (metavar "TYPE NAME")
-                                <*> parseTySynOption
+parseCommand = subparser $ subCommand <> showCommand
+  where subCommand = command "substitude" (info parseSubCommand (progDesc "Get the blueprint of a function or type with term substitution"))
+        showCommand = command "show" (info parseShowCommand (progDesc "Show the blueprint of a function or type in given format"))
 
 parseSubCommand :: Parser Entity
-parseSubCommand = SubstituteE <$> parseEntityName <*> parseSubLevel
-  where parseSubLevel = optional $ option auto (long "max-level" <> short 'L' <> help "Maximum level of substitution")
+parseSubCommand = SubstituteE <$> parseEntityName <*> many parseEntityName
 
 parseEntityName :: Parser EntityName
 parseEntityName = argument str (metavar "NAME")
 
 parseShowCommand :: Parser Entity
-parseShowCommand = ShowE <$> parseEntityName <*> parseFormat
-  where
-    parseFormat = option parseOutputFmt (long "output-format" <> short 'o' <>
-      help "Output format. Can be 'ascii', 'img'")
-    parseOutputFmt :: ReadM OutputFormat
-    parseOutputFmt = str @String >>= \case
-      "ascii" -> pure FmtAscii
-      "img" -> pure FmtImg
-      _ -> readerError "Unsupported output format. Use 'ascii' or 'img'"
+parseShowCommand = ShowE <$> parseEntityName
 
 -- parses the Level option (number of the levels to go through AST)
 parseLevelOption :: Parser DepthLevel
@@ -89,10 +61,9 @@ parseLineNumber = switch (long "line-number" <> short 'n'
 
 -- parses the output type. as of version 1, the default output would be Minimal
 parseOutputType :: Parser OutputType
-parseOutputType = parseMinimal <|> parseImage <|> parseSource <|> parseJSON
+parseOutputType = parseAscii <|> parseImage <|> parseSource
   where parseImage = Image <$> option parseV (long "image" <> short 'i' <> metavar "FILE" <> value Browser <> help "Write the result to an image")
-        parseJSON = JSONOutput <$> option parseF (long "json" <> short 'j' <> metavar "FILE" <> value STDIO <> help "Write the result as a json file")
-        parseMinimal = Minimal <$> option parseF (long "minamal" <> short 'm' <> value STDIO <> help "Prints a minimal result to Stdio or a filepath")
+        parseAscii = Ascii <$> option parseF (long "minamal" <> short 'm' <> value STDIO <> help "Prints a minimal result to Stdio or a filepath")
         parseSource = SourceCode <$> option parseF (long "source-code" <> short 's' <> value STDIO <> help "Write the result as a Haskell source to a filePath")
         parseF = maybeReader $ \x -> Just (File x)
         parseV = maybeReader $ \x -> Just (DumpFile x)

--- a/blueprint-core/blueprint-core.cabal
+++ b/blueprint-core/blueprint-core.cabal
@@ -29,12 +29,15 @@ source-repository head
 library
   exposed-modules:
       Development.Blueprint
-      Development.Blueprint.App
       Development.Blueprint.Compute
       Development.Blueprint.Compute.AST
+      Development.Blueprint.Compute.CompEnv
       Development.Blueprint.Compute.Morphisms
       Development.Blueprint.Compute.Search
       Development.Blueprint.Error
+      Development.Blueprint.Monad
+      Development.Blueprint.Monad.BP
+      Development.Blueprint.Monad.Comp
       Development.Blueprint.Types
       Development.Blueprint.Types.AST
       Development.Blueprint.Types.Compute
@@ -71,8 +74,11 @@ library
       GeneralizedNewtypeDeriving
       DeriveFunctor
       LambdaCase
+      FunctionalDependencies
+      UndecidableInstances
       FlexibleContexts
       DerivingStrategies
+      FlexibleInstances
       MagicHash
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
@@ -129,8 +135,11 @@ test-suite blueprint-test
       GeneralizedNewtypeDeriving
       DeriveFunctor
       LambdaCase
+      FunctionalDependencies
+      UndecidableInstances
       FlexibleContexts
       DerivingStrategies
+      FlexibleInstances
       MagicHash
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:

--- a/blueprint-core/package.yaml
+++ b/blueprint-core/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - unix
 - directory
 - criterion
+# - hiedb
 
 
 default-extensions:

--- a/blueprint-core/package.yaml
+++ b/blueprint-core/package.yaml
@@ -63,8 +63,11 @@ default-extensions:
   - GeneralizedNewtypeDeriving
   - DeriveFunctor
   - LambdaCase
+  - FunctionalDependencies
+  - UndecidableInstances
   - FlexibleContexts
   - DerivingStrategies
+  - FlexibleInstances
   - MagicHash
 
 ghc-options:

--- a/blueprint-core/src/Development/Blueprint.hs
+++ b/blueprint-core/src/Development/Blueprint.hs
@@ -1,53 +1,60 @@
 {-
 This module is the frontend to all the functionalities provided by blueprint and
-should be the only module needed in order to make a GUI client for Blueprint
+should be sufficient for most use cases
 -}
 
 module Development.Blueprint where
 
-import           Control.Monad.Except                    ( MonadError (..) )
-import           Control.Monad.Reader                    ( MonadIO (liftIO),
-                                                           MonadReader,
-                                                           (<=<), ask )
+import           Control.Monad.Except              ( MonadError (..) )
+import           Control.Monad.Reader              ( MonadIO (liftIO),
+                                                     MonadReader, ask, (<=<) )
 
-import           Development.Blueprint.Compute.AST       ( tcModuleToTcGblEnv )
-import           Development.Blueprint.Error             ( PipelineError (..) )
+import           Development.Blueprint.Compute.AST ( tcModuleToTcGblEnv )
+import           Development.Blueprint.Error       ( PipelineError (..) )
 
-import           GHC                                     ( Backend (..),
-                                                           HsGroup (hs_annds, hs_valds),
-                                                           LoadHowMuch (..),
-                                                           ModSummary (..),
-                                                           ParsedModule (..),
-                                                           backend,
-                                                           getModSummary,
-                                                           getSessionDynFlags,
-                                                           guessTarget,
-                                                           hs_valds, load,
-                                                           mkModuleName,
-                                                           setSessionDynFlags,
-                                                           setTargets,
-                                                           typecheckModule, Module, LHsBinds, GhcTc, TyCon, ClsInst, FamInst, GhcRn, RealSrcLoc, RealSrcSpan, LImportDecl )
-import           GHC.Driver.Monad                        ( GhcMonad (..) )
-import           GHC.Driver.Session                      ( DynFlags (backend, ghcLink, ghcMode),
-                                                           GhcLink (LinkInMemory),
-                                                           GhcMode (CompManager) )
-import           GHC.Tc.Types                            ( TcGblEnv (..) )
-import           GHC.Types.Name.Reader                   ( GlobalRdrEnv )
-import           GHC.Types.Name.Set                      ( DefUses )
+import           GHC                               ( Backend (..), ClsInst,
+                                                     DynFlags (backend, ghcLink, ghcMode),
+                                                     FamInst,
+                                                     GhcLink (LinkInMemory),
+                                                     GhcMode (CompManager),
+                                                     GhcPs, GhcRn, GhcTc,
+                                                     HsExpr (HsUnboundVar, HsVar),
+                                                     HsGroup (hs_annds, hs_valds),
+                                                     LHsBinds, LHsExpr,
+                                                     LImportDecl,
+                                                     LoadHowMuch (..),
+                                                     ModSummary (..), Module,
+                                                     Name, ParsedModule (..),
+                                                     RealSrcLoc, RealSrcSpan,
+                                                     TyCon, backend,
+                                                     getModSummary,
+                                                     getSessionDynFlags,
+                                                     guessTarget, hs_valds,
+                                                     load, mkModuleName,
+                                                     setSessionDynFlags,
+                                                     setTargets,
+                                                     typecheckModule, HsRecField' (HsRecField) )
+import           GHC.Core.FamInstEnv               ( FamInstEnv )
+import           GHC.Core.InstEnv                  ( InstEnv )
+import           GHC.Core.PatSyn                   ( PatSyn )
+import           GHC.Driver.Monad                  ( GhcMonad (..) )
+import           GHC.Plugins                       ( AnnEnv, Annotation )
+import           GHC.Tc.Types                      ( TcGblEnv (..) )
+import           GHC.Types.Name.Reader             ( GlobalRdrEnv )
+import           GHC.Types.Name.Set                ( DefUses )
+import           GHC.Types.TypeEnv                 ( TypeEnv )
 
-import           HIE.Bios                                ( CradleLoadResult (CradleSuccess),
-                                                           findCradle,
-                                                           getCompilerOptions,
-                                                           loadCradle )
-import           HIE.Bios.Environment                    ( initSession )
+import           HIE.Bios                          ( CradleLoadResult (CradleSuccess),
+                                                     findCradle,
+                                                     getCompilerOptions,
+                                                     loadCradle )
+import           HIE.Bios.Environment              ( initSession )
 
+import           Language.Haskell.Syntax.Expr
+import           Language.Haskell.Syntax.Decls
+import           Language.Haskell.Syntax.Binds
 
-import           System.Directory                        ( getCurrentDirectory )
-import GHC.Types.TypeEnv (TypeEnv)
-import GHC.Core.InstEnv (InstEnv)
-import GHC.Plugins (AnnEnv, Annotation)
-import GHC.Core.PatSyn (PatSyn)
-import GHC.Core.FamInstEnv (FamInstEnv)
+import           System.Directory                  ( getCurrentDirectory )
 
 
 -- | Tries to find the module name by looking for the 'module' keyword
@@ -58,15 +65,12 @@ findModuleName = nonMainModule . dropWhile (/= "module") . words
         nonMainModule _       = throwError CouldntFindModName
 
 
-
 -- | A variant of findModuleName which will assume a source without declare module name is the Main module
 findModuleName' :: (MonadError PipelineError m) => String -> m String
 findModuleName' = nonMainModule . dropWhile (/= "module") . words
   where nonMainModule []      = throwError EmptySrcFile
         nonMainModule (_:x:_) = return x
         nonMainModule _       = return "Main"
-
-
 
 
 -- | Sets up the right environment for ghc to start doing its job
@@ -105,6 +109,7 @@ instance (GhcMonad m, MonadReader a m) => GhcReader a m
 seeFromTcGblEnv :: GhcReader ParsedModule m => (TcGblEnv -> s) -> m s
 seeFromTcGblEnv fieldSelector = (return . fieldSelector . tcModuleToTcGblEnv <=< typecheckModule) =<< ask
 
+-- | Utility functions for accessing fields from TcGblEnv
 
 seeDefUses :: GhcReader ParsedModule m => m DefUses
 seeDefUses = seeFromTcGblEnv tcg_dus
@@ -170,3 +175,36 @@ seeAnnotations = seeFromTcGblEnv tcg_anns
 
 seeImports :: GhcReader ParsedModule m => m [LImportDecl GhcRn]
 seeImports = seeFromTcGblEnv tcg_rn_imports
+
+
+substitute :: HsExpr GhcPs -> HsExpr GhcPs
+substitute (HsVar a b)        = undefined
+substitute (HsUnboundVar a b) = undefined
+substitute (HsRecFld a b )     = undefined
+substitute (HsOverLabel a b)        = undefined
+substitute (HsIPVar a b)        = undefined
+substitute (HsOverLit a b )        = undefined
+substitute (HsLit a b )        = undefined
+substitute (HsLam a b )        = undefined
+substitute (HsLamCase a b) = undefined
+substitute (HsApp a b c) = undefined
+substitute (HsAppType a b c) = undefined
+substitute (OpApp a b c d) = undefined
+substitute (OpApp a b c d) = undefined
+substitute (NegApp a b c) = undefined
+substitute (HsPar a b) = undefined
+substitute (SectionL a b c) = undefined
+substitute (SectionR a b c) = undefined
+substitute (ExplicitTuple a b c) = undefined
+substitute (ExplicitSum a b c d) = undefined
+substitute (HsCase a b c) = undefined
+substitute (HsIf a b c d) = undefined
+substitute (HsMultiIf a b) = undefined
+substitute (HsLet a b c) = undefined
+substitute (HsDo a b c) = undefined
+substitute (ExplicitList a b) = undefined
+substitute (RecordCon a b c) = undefined
+substitute (RecordUpd a b c) = undefined
+substitute (HsGetField a b c) = undefined
+substitute (HsProjection a b) = undefined
+substitute _ = undefined

--- a/blueprint-core/src/Development/Blueprint.hs
+++ b/blueprint-core/src/Development/Blueprint.hs
@@ -8,45 +8,31 @@ module Development.Blueprint where
 import           Control.Monad.Except                    ( MonadError (..) )
 import           Control.Monad.Reader                    ( MonadIO (liftIO),
                                                            MonadReader,
-                                                           MonadTrans (lift),
-                                                           (<=<) )
-import           Control.Monad.Trans.Except              ( ExceptT, except,
-                                                           throwE )
+                                                           (<=<), ask )
 
-import           Development.Blueprint.App               ( BluePrint (..) )
-import           Development.Blueprint.Compute.AST       ( parseSourceFile,
-                                                           tcModuleToTcGblEnv,
-                                                           valBindsToHsBinds )
-import           Development.Blueprint.Compute.Morphisms ( entityToGlbRdrElt )
+import           Development.Blueprint.Compute.AST       ( tcModuleToTcGblEnv )
 import           Development.Blueprint.Error             ( PipelineError (..) )
-import           Development.Blueprint.Types             ( Entity )
 
 import           GHC                                     ( Backend (..),
-                                                           GhcPass (GhcRn),
-                                                           GhcRn,
-                                                           HsGroup (hs_valds),
+                                                           HsGroup (hs_annds, hs_valds),
                                                            LoadHowMuch (..),
                                                            ModSummary (..),
-                                                           Name (..),
                                                            ParsedModule (..),
-                                                           RenamedSource,
                                                            backend,
                                                            getModSummary,
                                                            getSessionDynFlags,
                                                            guessTarget,
                                                            hs_valds, load,
                                                            mkModuleName,
-                                                           parseModule,
                                                            setSessionDynFlags,
                                                            setTargets,
-                                                           typecheckModule )
-import           GHC.Driver.Monad                        ( GhcMonad (..),
-                                                           getSessionDynFlags )
+                                                           typecheckModule, Module, LHsBinds, GhcTc, TyCon, ClsInst, FamInst, GhcRn, RealSrcLoc, RealSrcSpan, LImportDecl )
+import           GHC.Driver.Monad                        ( GhcMonad (..) )
 import           GHC.Driver.Session                      ( DynFlags (backend, ghcLink, ghcMode),
                                                            GhcLink (LinkInMemory),
                                                            GhcMode (CompManager) )
 import           GHC.Tc.Types                            ( TcGblEnv (..) )
-import           GHC.Types.Name.Reader                   ( GlobalRdrElt )
+import           GHC.Types.Name.Reader                   ( GlobalRdrEnv )
 import           GHC.Types.Name.Set                      ( DefUses )
 
 import           HIE.Bios                                ( CradleLoadResult (CradleSuccess),
@@ -55,14 +41,32 @@ import           HIE.Bios                                ( CradleLoadResult (Cra
                                                            loadCradle )
 import           HIE.Bios.Environment                    ( initSession )
 
+
 import           System.Directory                        ( getCurrentDirectory )
+import GHC.Types.TypeEnv (TypeEnv)
+import GHC.Core.InstEnv (InstEnv)
+import GHC.Plugins (AnnEnv, Annotation)
+import GHC.Core.PatSyn (PatSyn)
+import GHC.Core.FamInstEnv (FamInstEnv)
 
 
+-- | Tries to find the module name by looking for the 'module' keyword
 findModuleName :: (MonadError PipelineError m) => String -> m String
 findModuleName = nonMainModule . dropWhile (/= "module") . words
   where nonMainModule []      = throwError EmptySrcFile
         nonMainModule (_:x:_) = return x
         nonMainModule _       = throwError CouldntFindModName
+
+
+
+-- | A variant of findModuleName which will assume a source without declare module name is the Main module
+findModuleName' :: (MonadError PipelineError m) => String -> m String
+findModuleName' = nonMainModule . dropWhile (/= "module") . words
+  where nonMainModule []      = throwError EmptySrcFile
+        nonMainModule (_:x:_) = return x
+        nonMainModule _       = return "Main"
+
+
 
 
 -- | Sets up the right environment for ghc to start doing its job
@@ -92,11 +96,77 @@ initializeGhc filePath = do
     setupOptions _ = throwError FailedCradle
 
 
-seeFromTcGblEnv :: (GhcMonad m, MonadReader ModSummary m) => (TcGblEnv -> s) -> m s
-seeFromTcGblEnv fieldSelector = do
-  parsed <- parseSourceFile
-  return . fieldSelector . tcModuleToTcGblEnv <=< typecheckModule $ parsed
+-- This constraint synonym is defined only for better readability in type signatures
+class (GhcMonad m, MonadReader a m) => GhcReader a m | m -> a
+instance (GhcMonad m, MonadReader a m) => GhcReader a m
 
 
-seeDefUses :: (GhcMonad m, MonadReader ModSummary m) => m DefUses
+-- | Gets a field selector from TcGblEnv and then runs it on the ModSummary
+seeFromTcGblEnv :: GhcReader ParsedModule m => (TcGblEnv -> s) -> m s
+seeFromTcGblEnv fieldSelector = (return . fieldSelector . tcModuleToTcGblEnv <=< typecheckModule) =<< ask
+
+
+seeDefUses :: GhcReader ParsedModule m => m DefUses
 seeDefUses = seeFromTcGblEnv tcg_dus
+
+
+seeModule :: GhcReader ParsedModule m => m Module
+seeModule = seeFromTcGblEnv tcg_mod
+
+
+seeGlobalRdrEnv :: GhcReader ParsedModule m => m GlobalRdrEnv
+seeGlobalRdrEnv = seeFromTcGblEnv tcg_rdr_env
+
+
+seeFamilyInstEnv :: GhcReader ParsedModule m => m FamInstEnv
+seeFamilyInstEnv = seeFromTcGblEnv tcg_fam_inst_env
+
+
+seeTypeEnv :: GhcReader ParsedModule m => m TypeEnv
+seeTypeEnv = seeFromTcGblEnv tcg_type_env
+
+
+seeInstEnv :: GhcReader ParsedModule m => m InstEnv
+seeInstEnv = seeFromTcGblEnv tcg_inst_env
+
+
+seeAnnEnv :: GhcReader ParsedModule m => m AnnEnv
+seeAnnEnv = seeFromTcGblEnv tcg_ann_env
+
+
+seeRenamedDecls :: (GhcReader ParsedModule m, MonadError PipelineError m) => m (HsGroup GhcRn)
+seeRenamedDecls = seeFromTcGblEnv tcg_rn_decls >>= reportRenamed
+  where reportRenamed Nothing  = throwError GhcCouldntRename
+        reportRenamed (Just x) = return x
+
+
+seeBinds :: GhcReader ParsedModule m => m (LHsBinds GhcTc)
+seeBinds = seeFromTcGblEnv tcg_binds
+
+
+seeTyCons :: GhcReader ParsedModule m => m [TyCon]
+seeTyCons = seeFromTcGblEnv tcg_tcs
+
+
+seeInsts :: GhcReader ParsedModule m => m [ClsInst]
+seeInsts = seeFromTcGblEnv tcg_insts
+
+
+seeFamilyInsts :: GhcReader ParsedModule m => m [FamInst]
+seeFamilyInsts = seeFromTcGblEnv tcg_fam_insts
+
+
+seeRealSrcSpan :: GhcReader ParsedModule m => m RealSrcSpan
+seeRealSrcSpan = seeFromTcGblEnv tcg_top_loc
+
+
+seePatternSynonyms :: GhcReader ParsedModule m => m [PatSyn]
+seePatternSynonyms = seeFromTcGblEnv tcg_patsyns
+
+
+seeAnnotations :: GhcReader ParsedModule m => m [Annotation]
+seeAnnotations = seeFromTcGblEnv tcg_anns
+
+
+seeImports :: GhcReader ParsedModule m => m [LImportDecl GhcRn]
+seeImports = seeFromTcGblEnv tcg_rn_imports

--- a/blueprint-core/src/Development/Blueprint/Compute/CompEnv.hs
+++ b/blueprint-core/src/Development/Blueprint/Compute/CompEnv.hs
@@ -1,0 +1,63 @@
+-- | Working with the Computation environment
+
+module Development.Blueprint.Compute.CompEnv where
+
+
+import           Control.Lens.Combinators          ( makeLenses )
+
+import           Data.Maybe                        ( fromJust )
+import           Data.Tree.Lens                    ()
+
+import           Development.Blueprint.Types.Error ( CompEnvError (..) )
+
+import           GHC                               ( ClsInst, FamInst, GhcRn,
+                                                     HsGroup, LHsExpr, Module,
+                                                     ParsedModule (..),
+                                                     ParsedSource (..), TyCon )
+import           GHC.Core.FamInstEnv               ( FamInstEnv )
+import           GHC.Core.InstEnv                  ( InstEnv )
+import           GHC.Core.PatSyn                   ( PatSyn )
+import           GHC.Hs
+import           GHC.Plugins                       ( AnnEnv )
+import           GHC.Tc.Types                      ( ImportAvails,
+                                                     TcGblEnv (..) )
+import           GHC.Types.Name.Reader             ( GlobalRdrEnv )
+import           GHC.Types.Name.Set                ( DefUses )
+import           GHC.Types.TypeEnv                 ( TypeEnv )
+
+
+data CompEnv a = CompEnv { _globalRdrEnv      :: GlobalRdrEnv
+                         , _expr              :: LHsExpr a
+                         , _renamedDecls      :: HsGroup a
+                         , _currentModule     :: Module
+                         , _typeEnv           :: TypeEnv
+                         , _annotationEnv     :: AnnEnv
+                         , _instanceEnv       :: InstEnv
+                         , _topInstances      :: [ClsInst]
+                         , _defUses           :: DefUses
+                         , _familyInstances   :: [FamInst]
+                         , _familyInstanceEnv :: FamInstEnv
+                         , _imports           :: ImportAvails
+                         , _patternSynonyms   :: [PatSyn]
+                         , _topTyCons         :: [TyCon] }
+
+makeLenses ''CompEnv
+
+-- | Initialize a computation environment from TcGblEnv, and parsers AST
+initCompEnv :: TcGblEnv -> Either CompEnvError (CompEnv GhcRn)
+initCompEnv (tcg_rn_decls -> Nothing) = Left RnDeclError
+initCompEnv TcGblEnv{..}             = Right
+  $ CompEnv { _globalRdrEnv      = tcg_rdr_env
+            , _renamedDecls      = fromJust tcg_rn_decls
+            , _currentModule     = tcg_mod
+            , _typeEnv           = tcg_type_env
+            , _annotationEnv     = tcg_ann_env
+            , _instanceEnv       = tcg_inst_env
+            , _topInstances      = tcg_insts
+            , _defUses           = tcg_dus
+            , _familyInstanceEnv = tcg_fam_inst_env
+            , _familyInstances   = tcg_fam_insts
+            , _imports           = tcg_imports
+            , _patternSynonyms   = tcg_patsyns
+            , _topTyCons         = tcg_tcs
+            }

--- a/blueprint-core/src/Development/Blueprint/Compute/Morphisms.hs
+++ b/blueprint-core/src/Development/Blueprint/Compute/Morphisms.hs
@@ -21,18 +21,15 @@ import           GHC.Types.Name.Reader           ( GlobalRdrElt (..),
                                                    GlobalRdrEnv (..),
                                                    lookupGlobalRdrEnv )
 
-funcOccString :: Scope -> Func
-funcOccString (TopLevel func)   = func
-funcOccString (ParentS _ lFunc) = lFunc
-
+-- FIXME: should work for both functions and types
 getEntityOccString :: Entity -> EntityOccDef
-getEntityOccString (DataTypeE t)   = typeName t
-getEntityOccString (FunctionE s _) = funcOccString s
+getEntityOccString (SubstituteE s _) = s
+getEntityOccString (ShowE s) = s
 
+-- FIXME: should work for both functions and types
 occNameFromEntity :: Entity -> OccName
-occNameFromEntity (DataTypeE t)   = mkOccName tcName . unpack $ typeName t
-occNameFromEntity (FunctionE s _) = mkOccName varName . unpack $ funcOccString s
-
+occNameFromEntity (SubstituteE s _) = mkOccName varName . unpack $ s
+occNameFromEntity (ShowE s) = mkOccName varName . unpack $ s
 
 -- This function should only be used to search the entity gathered from command line
 entityToGlbRdrElt :: Entity -> GlobalRdrEnv -> Either String GlobalRdrElt

--- a/blueprint-core/src/Development/Blueprint/Compute/Search.hs
+++ b/blueprint-core/src/Development/Blueprint/Compute/Search.hs
@@ -18,7 +18,7 @@ import           Data.Maybe                              ( fromJust )
 import           Data.Tree                               ( Tree (..) )
 import           Data.Tree.Lens                          ()
 
-import           Development.Blueprint.App               ( BluePrint (..) )
+import           Development.Blueprint.Monad ( BluePrint (..) )
 import           Development.Blueprint.Compute.Morphisms ( entityToName,
                                                            occNameFromEntity )
 import           Development.Blueprint.Types             ( Entity (..),
@@ -54,39 +54,6 @@ import           GHC.Types.TypeEnv                       ( TypeEnv )
 
 
 -- TODO experiment with st
-data CompEnv a = CompEnv { _globalRdrEnv      :: GlobalRdrEnv
-                         , _renamedDecls      :: HsGroup a
-                         , _currentModule     :: Module
-                         , _typeEnv           :: TypeEnv
-                         , _annotationEnv     :: AnnEnv
-                         , _instanceEnv       :: InstEnv
-                         , _topInstances      :: [ClsInst]
-                         , _defUses           :: DefUses
-                         , _familyInstances   :: [FamInst]
-                         , _familyInstanceEnv :: FamInstEnv
-                         , _imports           :: ImportAvails
-                         , _patternSynonyms   :: [PatSyn]
-                         , _topTyCons         :: [TyCon] }
-
-makeLenses ''CompEnv
-
--- TODO see if you can use ST for better performance and compatibitly with the current
--- typechecker API
-initCompEnv :: TcGblEnv -> Either CompEnvError (CompEnv GhcRn)
-initCompEnv (tcg_rn_decls -> Nothing) = Left RnDeclError
-initCompEnv TcGblEnv{..} = Right $ CompEnv { _globalRdrEnv = tcg_rdr_env
-                                           , _renamedDecls = fromJust tcg_rn_decls
-                                           , _currentModule = tcg_mod
-                                           , _typeEnv = tcg_type_env
-                                           , _annotationEnv = tcg_ann_env
-                                           , _instanceEnv = tcg_inst_env
-                                           , _topInstances = tcg_insts
-                                           , _defUses = tcg_dus
-                                           , _familyInstanceEnv = tcg_fam_inst_env
-                                           , _familyInstances = tcg_fam_insts
-                                           , _imports = tcg_imports
-                                           , _patternSynonyms = tcg_patsyns
-                                           , _topTyCons = tcg_tcs}
 
 
 searchOccName :: Monad m => SearchEnv -> GlobalRdrEnv -> m [GlobalRdrElt]

--- a/blueprint-core/src/Development/Blueprint/Monad.hs
+++ b/blueprint-core/src/Development/Blueprint/Monad.hs
@@ -1,0 +1,14 @@
+-- | This module just reexports everything for convinience
+module Development.Blueprint.Monad (module Development.Blueprint.Monad.BP
+                                   ,module Development.Blueprint.Monad.Comp
+                                   ,module Control.Monad.Writer
+                                   ,module Control.Monad.Reader
+                                   ,module Control.Monad.Except
+                                   ,module Control.Monad) where
+
+import Development.Blueprint.Monad.BP
+import Development.Blueprint.Monad.Comp
+import Control.Monad.Writer
+import Control.Monad.Reader
+import Control.Monad.Except
+import Control.Monad

--- a/blueprint-core/src/Development/Blueprint/Monad/BP.hs
+++ b/blueprint-core/src/Development/Blueprint/Monad/BP.hs
@@ -1,7 +1,8 @@
-module Development.Blueprint.App ( runBluePrint
-           , bluePrint
-           , BluePrint(..)
-           ) where
+-- | The module for working with the Blueprint monad
+
+module Development.Blueprint.Monad.BP (BluePrint
+                                      ,runBluePrint
+                                      ,bluePrint) where
 
 import           Control.Monad.Trans.Except ( ExceptT, runExceptT )
 import           Control.Monad.Trans.Reader ( ReaderT (runReaderT), ask )
@@ -9,11 +10,6 @@ import           Control.Monad.Trans.Writer ( WriterT (runWriterT) )
 
 
 
--- newtype BluePrint a w m b = BT { unBluePrint :: ReaderT a (WriterT w m) b}
---   deriving (Functor, Applicative, Monad, MonadReader a, MonadWriter w, MonadIO)
-
-
--- TODO change the position of e
 type BluePrint e a w m = ReaderT a (ExceptT e (WriterT w m))
 
 -- runs a Computation within the BluePrint monad

--- a/blueprint-core/src/Development/Blueprint/Monad/Comp.hs
+++ b/blueprint-core/src/Development/Blueprint/Monad/Comp.hs
@@ -1,0 +1,3 @@
+-- | The Computation Monad
+
+module Development.Blueprint.Monad.Comp where

--- a/blueprint-core/src/Development/Blueprint/Types.hs
+++ b/blueprint-core/src/Development/Blueprint/Types.hs
@@ -1,15 +1,20 @@
-module Development.Blueprint.Types( Entity(..), SearchEnv(..)
+module Development.Blueprint.Types( Entity(..), EntityName, SearchEnv(..)
             , Scope(..), DepthLevel(..)
             , TypeC(..), EntityOccDef
             , ParentFunc, Func
-            , LocalFunc, OutputType(..)
+            , LocalFunc, OutputFormat(..), OutputType(..)
             , Print(..), VisualView(..)) where
 
 import           Data.Text ( Text )
 
+data OutputFormat = FmtAscii
+                  | FmtImg
+                  deriving (Show, Eq)
 
 data Entity = FunctionE Scope Bool
             | DataTypeE TypeC
+            | SubstituteE EntityName (Maybe SubLevel)
+            | ShowE EntityName OutputFormat
             deriving (Show, Eq)
 
 data TypeC = TypeC { typeName       :: Text
@@ -19,6 +24,8 @@ type LocalFunc     = Text
 type ParentFunc    = Text
 type Func          = Text
 type EntityOccDef  = Text
+type EntityName    = Text
+type SubLevel      = Int
 
 
 data Scope = TopLevel Func

--- a/blueprint-core/src/Development/Blueprint/Types.hs
+++ b/blueprint-core/src/Development/Blueprint/Types.hs
@@ -2,19 +2,13 @@ module Development.Blueprint.Types( Entity(..), EntityName, SearchEnv(..)
             , Scope(..), DepthLevel(..)
             , TypeC(..), EntityOccDef
             , ParentFunc, Func
-            , LocalFunc, OutputFormat(..), OutputType(..)
+            , LocalFunc, OutputType(..)
             , Print(..), VisualView(..)) where
 
 import           Data.Text ( Text )
 
-data OutputFormat = FmtAscii
-                  | FmtImg
-                  deriving (Show, Eq)
-
-data Entity = FunctionE Scope Bool
-            | DataTypeE TypeC
-            | SubstituteE EntityName (Maybe SubLevel)
-            | ShowE EntityName OutputFormat
+data Entity = SubstituteE EntityName [EntityName]
+            | ShowE EntityName
             deriving (Show, Eq)
 
 data TypeC = TypeC { typeName       :: Text
@@ -25,8 +19,6 @@ type ParentFunc    = Text
 type Func          = Text
 type EntityOccDef  = Text
 type EntityName    = Text
-type SubLevel      = Int
-
 
 data Scope = TopLevel Func
            | ParentS ParentFunc LocalFunc deriving (Eq, Show)
@@ -44,8 +36,7 @@ data VisualView = Browser
 
 data OutputType = Image VisualView -- SVG view
                 | SourceCode Print -- Haskell source code
-                | Minimal Print    -- like UNIX tree command
-                | JSONOutput Print -- JSON Output
+                | Ascii Print    -- like UNIX tree command
                 deriving (Show, Eq)
 
 data SearchEnv = SEnv { entity     :: Entity      -- The thing we are searching for

--- a/blueprint-core/src/Development/Blueprint/Types/Search.hs
+++ b/blueprint-core/src/Development/Blueprint/Types/Search.hs
@@ -1,3 +1,2 @@
-module Development.Blueprint.Types.Search(CompEnv(..)) where
-
-import           Development.Blueprint.Compute.Search (CompEnv(..))
+module Development.Blueprint.Types.Search where
+import           Development.Blueprint.Compute.CompEnv

--- a/blueprint-core/stack.yaml
+++ b/blueprint-core/stack.yaml
@@ -29,8 +29,6 @@
 packages:
 - .
 
-  # extra-deps:
-
   # - acme-missiles-0.3
   # - git: https://github.com/commercialhaskell/stack.git
   #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
@@ -40,6 +38,8 @@ resolver: lts-20.18
 
 
 extra-deps:
+  # - hiedb-0.4.2.0
+  # - hie-compat-0.3.1.0
   # override default flag values for local packages and extra-deps
   # flags: {}
 

--- a/notes.org
+++ b/notes.org
@@ -275,3 +275,7 @@ main = runGhcT (Just libdir) $ do
 ** TODO Version 2
 + [ ] not having to run the command within the project
 + [ ] refactoring by knowing exactly what we need and what we don't
+* IDEA Explaining blueprint
+when you are trying to talk about blueprint, use the fact that we all use code snippets when we are trying to create a slide for better engagement and in order to show the others what the purpose of the project is.
+
+Compare it with outoing call hierarchy


### PR DESCRIPTION
```
$ blueprint-cli-exe --help
A different approach to showing outgoing call hierarchy for Haskell source code.

Usage: blueprint-cli-exe COMMAND [-L|--level NUMBER] [-c|--color] 
                         [-n|--line-number] 
                         [(-a|--ascii ARG) | (-i|--image FILE) | 
                           (-s|--source-code ARG)] FILENAME

  Print recursive declerations of an entity

Available options:
  -L,--level NUMBER        Levels of implementation search in AST
  -c,--color               Show with syntax highlighting
  -n,--line-number         show the line numbers
  -a,--ascii ARG           Prints a minimal result to Stdio or a filepath
  -i,--image FILE          Write the result to an image
  -s,--source-code ARG     Write the result as a Haskell source to a filePath
  -h,--help                Show this help text

Available commands:
  substitude               Get the blueprint of a function or type with term
                           substitution
  show                     Show the blueprint of a function or type in given
                           format

```